### PR TITLE
fix: bookmark button is disabled for archived posts

### DIFF
--- a/src/modules/bookmark.ts
+++ b/src/modules/bookmark.ts
@@ -95,6 +95,7 @@ export async function renderBookmarkPost(post: Element, forced: boolean = false,
 
         const bookmarkButton = downVoteButton.cloneNode(true) as Element;
         bookmarkButton.classList.add(`pp_bookmark_post`);
+        bookmarkButton.removeAttribute(`disabled`);
         bookmarkButton.removeAttribute(`downvote`);
         bookmarkButton.setAttribute(`bookmark`, ``);
         downVoteButton.after(bookmarkButton);


### PR DESCRIPTION
Archived posts like this: 

https://www.reddit.com/r/reddit.com/comments/64a2o/frozen_ipod_problems_best_ipod_stuff/

Can be saved but cannot be upvoted/downvoted hence the inherited disabled attribute should be removed. `removeAttribute` doesn't throw any errors if the attribute doesn't exist.