### PR TITLE
feat: add user search functionality for hidden posts or comments

### DIFF
--- a/src/modules/app.less
+++ b/src/modules/app.less
@@ -6,3 +6,13 @@ faceplate-banner {
 .pp_hidden {
     display: none !important;
 }
+
+// reddit bug workaround - for viewports between 1200px and 1392px wide, some slight miscalculations
+// cause horizontal scrollbars to appear due to paddings.
+
+// NOTE: test from time to time to see if reddit has fixed this issue natively.
+@media (min-width: 1200px) {
+    .pp_mainFeed {
+        max-width: calc(100vw - var(--flex-nav-width,0px) - 15px) !important;
+    }
+}

--- a/src/modules/users/userPage.less
+++ b/src/modules/users/userPage.less
@@ -1,0 +1,6 @@
+.pp_user_hiddenPostsMessage {
+    padding-left: 1rem;
+    display: flex;
+    gap: 1rem;
+}
+

--- a/src/modules/users/userPage.ts
+++ b/src/modules/users/userPage.ts
@@ -1,8 +1,17 @@
+import { appendElement, buildElement, prependElement } from '../../utils/element';
 import { dynamicElement } from '../../utils/tools';
 import { initializePostObserver } from '../feed/feed';
 import { renderPost } from '../posts/posts';
+import { getCurrentUser } from './users';
+import style from './userPage.less';
+import { css } from '../customCSS';
+import { renderUIButton } from '../../utils/UI/button';
+
+css.addStyle(style);
 
 export async function renderUserPage(container: Element) {
+    renderUserSearchPosts(container);
+
     const feed = await dynamicElement(() => container.querySelector(`#subgrid-container`)?.querySelector(`shreddit-feed`));
 
     // render embedded posts
@@ -12,4 +21,40 @@ export async function renderUserPage(container: Element) {
 
     // render loaded posts
     initializePostObserver(feed);
+}
+
+async function renderUserSearchPosts(container: Element) {
+    const containerElement = (await dynamicElement(() => container.querySelector(`#subgrid-container`))) as HTMLElement;
+
+    const mainContent = containerElement.querySelector(`[data-testid="profile-main"]`);
+    const privateUserContainer = buildElement(`div`, `pp_user_hiddenPostsMessage`);
+    mainContent.after(privateUserContainer);
+
+    const currentUser = getCurrentUser();
+    const searchPostsUrl = `/user/${currentUser}/search/?q=&sort=new`;
+    const searchCommentsUrl = `/user/${currentUser}/search/?q=&sort=new&type=comments`;
+
+    renderUIButton(
+        privateUserContainer,
+        `Search User's Posts`,
+        () => {
+            window.location.href = searchPostsUrl;
+        },
+        {
+            variant: 'secondary',
+            size: 'small'
+        }
+    );
+
+    renderUIButton(
+        privateUserContainer,
+        `Search User's Comments`,
+        () => {
+            window.location.href = searchCommentsUrl;
+        },
+        {
+            variant: 'secondary',
+            size: 'small'
+        }
+    );
 }

--- a/src/modules/users/users.ts
+++ b/src/modules/users/users.ts
@@ -49,3 +49,8 @@ async function userDataLoader(userId: string): Promise<UserData> {
 
     return userData;
 }
+
+export function getCurrentUser(): string {
+    const raw = window.location.href.split(`reddit.com/user/`);
+    return raw.length > 1 ? raw[1].split(`/`)[0] : null;
+}


### PR DESCRIPTION
So this feature is to add these two buttons on profiles
That is to just search the user's profile for posts and comments. Simply put; a new reddit feature allowed users to "curate" their profiles by hiding all (or some) activities for the public but they are still searchable.
(reference: https://www.reddit.com/r/reddithelp/comments/1o0fmpb/ ) Check the profile of the author of the previous post and see their hidden activities when clicking the buttons.

- I also fixed an annoying horizontal scroll (native reddit bug) that just happens in all the pages.
- I didn't create a dedicated settings control for this feature, I couldn't see the need for it. @lnm95  if you think it needs a settings to disable it, please add one.
<img width="2132" height="642" alt="image" src="https://github.com/user-attachments/assets/6ad9262d-54bd-4986-8a9e-146d6e93493e" />


