### PR TITLE
feat: Hide in-feed community recommendations

### DIFF
--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -155,6 +155,7 @@ class SettingsManager {
     public UNWRAP_POST = new SettingBoolProperty(`unwrapPost`);
     public SHOW_POST_AUTHOR = new SettingBoolProperty(`showPostAuthor`);
     public SAVED_BOOKMARK_POSTS = new SettingDropdownProperty(`savedBookmarkPosts`, Object.values(BookmarkMode), 1);
+    public HIDE_COMMUNITY_RECOMMENDATIONS = new SettingBoolProperty(`hideCommunityRecommendations`, false);
 
     // comments
     public COMMENTS_SORT_BUTTONS = new SettingBoolProperty(`commentSortButtons`);

--- a/src/modules/settings/settingsWindow.ts
+++ b/src/modules/settings/settingsWindow.ts
@@ -77,6 +77,7 @@ function renderSettingsWindow(win: Window, context: any) {
     addSettingToggle(`Soft background`, `Make the background of posts with soft gradient color`, settings.BACKPLATES);
     addSettingToggle(`Show post's author`, `Relates to Home, Popular and All feeds`, settings.SHOW_POST_AUTHOR);
     addSettingOptions(`Save-post bookmarks`, `Show the save bookmark next to the vote buttons`, settings.SAVED_BOOKMARK_POSTS);
+    addSettingToggle(`Hide Community Recommendations`, `Hides the related communities section in feed`, settings.HIDE_COMMUNITY_RECOMMENDATIONS);
 
     addSubtittle(`Comments`);
     addSettingToggle(`Sort buttons`, `Unwrap the comment's sort buttons`, settings.COMMENTS_SORT_BUTTONS);

--- a/src/modules/subs/subs.ts
+++ b/src/modules/subs/subs.ts
@@ -70,6 +70,8 @@ export async function renderSub(main: Element) {
     renderFlairBar(main);
 
     renderHighlights(main);
+
+    renderRecommendedCommunities(main);
 }
 
 async function renderMasthead(main: Element) {
@@ -89,6 +91,16 @@ async function renderHighlights(main: Element) {
 
     if (highlightButton != null) {
         (highlightButton as HTMLElement).click();
+    }
+}
+
+async function renderRecommendedCommunities(main: Element) {
+    if (settings.HIDE_COMMUNITY_RECOMMENDATIONS.isDisabled()) return;
+
+    const recommendedCommunities = await dynamicElement(() => main?.querySelector(`in-feed-community-recommendations`), MAX_LOAD_LAG * 5);
+
+    if (recommendedCommunities != null) {
+        (recommendedCommunities as HTMLElement).remove();
     }
 }
 


### PR DESCRIPTION
Adds a new settings toggle for hiding the subreddit in-feed community recommendations (default: show)

<img width="1390" height="198" alt="Screenshot 2026-04-10 120213" src="https://github.com/user-attachments/assets/3e61f583-f42f-49ab-a889-494cae6deb2d" />
